### PR TITLE
Remove closing PHP tag from index.php

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -18,5 +18,3 @@ $app->get('/', function() use($app) {
 });
 
 $app->run();
-
-?>


### PR DESCRIPTION
As per PSR-2 article 2.2, files that contain only PHP code should not have a trailing closing PHP tag: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#22-files