### PR TITLE
Use PHP brand color

### DIFF
--- a/web/stylesheets/main.css
+++ b/web/stylesheets/main.css
@@ -23,7 +23,7 @@
 }
 .jumbotron .lang-logo {
   display: block;
-  background: #AEB2D5;
+  background: #777BB3;
   border-radius: 50%;
   overflow: hidden;
   width: 100px;

--- a/web/stylesheets/main.css
+++ b/web/stylesheets/main.css
@@ -23,7 +23,7 @@
 }
 .jumbotron .lang-logo {
   display: block;
-  background: #B01302;
+  background: #AEB2D5;
   border-radius: 50%;
   overflow: hidden;
   width: 100px;


### PR DESCRIPTION
The red logo clashes a bit with the purple background in my eyes, and I'm pretty sure this red was copied from the Ruby getting started guide where this red is a little more appropriate. This uses the primary color from the PHP logo, which works a little better with the purple background, and is a little more on brand for PHP.

## Before

![Screenshot 2023-07-05 at 9 37 06 AM](https://github.com/heroku/php-getting-started/assets/917672/db56430f-98af-4f5c-8935-aa0dd74f69df)


## After
![Screenshot 2023-07-05 at 9 48 56 AM](https://github.com/heroku/php-getting-started/assets/917672/9e1d70ac-59eb-437c-be04-c34de4dc7eec)

