### PR TITLE
Added viewport meta tag

### DIFF
--- a/views/header.html
+++ b/views/header.html
@@ -1,4 +1,5 @@
 <title>PHP Getting Started on Heroku</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="stylesheet" type="text/css" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script type="text/javascript" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Standard meta tag to optimize pages for mobile screens. Works well with this Bootstrap theme.

With viewport meta tag:
![with-viewport-meta-tag Small](https://github.com/user-attachments/assets/bf1c4fbc-301b-49ab-8302-654db2a2bdcd)

Without viewport meta tag:
![without-viewport-meta-tag Small](https://github.com/user-attachments/assets/cf2484be-d567-4b6a-936b-5874f59fd91a)

GUS-W-16610879