### PR TITLE
Fix GUSINFO metadata in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Default to requesting pull request reviews from the Heroku Languages team.
 #ECCN:Open Source
-#GUSINFO:Languages,Heroku PHP Platform
+#GUSINFO:Heroku - Languages,Heroku PHP Platform
 * @heroku/languages
 
 # However, request review from the Heroku language owner for files that are updated

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
+.DS_Store
 .env


### PR DESCRIPTION
Since the Languages team was renamed to `Heroku - Languages` in GUS some time ago.

GUS-W-21708465.