### PR TITLE
Update CODEOWNERS for change in language owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,5 @@
 # Note: Delete this file if you are copying the code in this repository into your own project.
 
-# Default to requesting pull request reviews from the Heroku Languages team.
 #ECCN:Open Source
 #GUSINFO:Heroku - Languages,Heroku PHP Platform
 * @heroku/languages
-
-# However, request review from the Heroku language owner for files that are updated
-# by Dependabot, to reduce team review request noise.
-composer.json @dzuelke
-composer.lock @dzuelke


### PR DESCRIPTION
Now matches what we do for other jointly-owned repos (such as those for Go).